### PR TITLE
USRP driver GPS synchronization and logging time stamps

### DIFF
--- a/driver_config__east.ini
+++ b/driver_config__east.ini
@@ -20,3 +20,4 @@ CUDADriverPort = 55420
 USRPDriverPort = 54420
 CUDADriverHostnames_R1 = localhost
 CUDADriverHostnames_R2 = 192.168.100.2
+GPSOctoclockHostname = 192.168.0.10

--- a/driver_config__east.ini
+++ b/driver_config__east.ini
@@ -20,4 +20,4 @@ CUDADriverPort = 55420
 USRPDriverPort = 54420
 CUDADriverHostnames_R1 = localhost
 CUDADriverHostnames_R2 = 192.168.100.2
-GPSOctoclockHostname = 192.168.0.10
+GPSOctoclockHostname =

--- a/driver_config__west.ini
+++ b/driver_config__west.ini
@@ -20,3 +20,4 @@ CUDADriverPort = 55420
 USRPDriverPort = 54420
 CUDADriverHostnames_R1 = localhost
 CUDADriverHostnames_R2 = 192.168.100.2
+GPSOctoclockHostname = 192.168.0.10

--- a/driver_config__west.ini
+++ b/driver_config__west.ini
@@ -20,4 +20,4 @@ CUDADriverPort = 55420
 USRPDriverPort = 54420
 CUDADriverHostnames_R1 = localhost
 CUDADriverHostnames_R2 = 192.168.100.2
-GPSOctoclockHostname = 192.168.0.10
+GPSOctoclockHostname =

--- a/srr.py
+++ b/srr.py
@@ -93,6 +93,8 @@ USE_USRP_DRIVER_WRAPPER = True
 nSecs_restart_pause = 10
 delay_between_driver_and_server = 10
 
+editors = ['emacs','gedit','nano','vi','vim']
+
 def myPrint(msg):
    print("||>  {}".format(msg))
 basePrintLine = "||>==============================================================="
@@ -288,6 +290,8 @@ def get_usrp_driver_processes():
     processList = get_processes()
     usrpProcesses = []
     for line in processList:
+        if any(x in line for x in editors):
+            continue
         if 'usrp_driver' in line:
             wordList = [word for word in line.split(" " ) if word != ""]
             try:

--- a/usrp_driver/Makefile
+++ b/usrp_driver/Makefile
@@ -8,8 +8,8 @@ linux_libs=-lboost_thread -lboost_system -pthread -l argtable2 -lboost_date_time
 INCLUDES=-I"${HOME}/repos/uhd/host/include" \
 	 -I"${HOME}/repos/uhd/host/include/uhd/types" \
 	 -I"${HOME}/repos/uhd/host/include/uhd/usrp" \
-	 -I"${HOME}/repos/rst-ros/include/base" \
-	 -I"${HOME}/repos/rst-ros/include/superdarn"
+	 -I"${RSTPATH}/include/base" \
+	 -I"${RSTPATH}/include/superdarn"
 
 CPP_SOURCES=usrp_driver.cpp dio.cpp tx_worker.cpp rx_worker.cpp usrp_utils.cpp
 

--- a/usrp_driver/dio.cpp
+++ b/usrp_driver/dio.cpp
@@ -173,7 +173,7 @@ void init_timing_signals(
     uhd::set_thread_priority_safe(priority,realtime);
 
     double debugt = usrp->get_time_now().get_real_secs();
-    DEBUG_PRINT("DIO queing GPIO commands at usrp_time %2.4f\n", debugt);
+    DEBUG_PRINT("%s: DIO queing GPIO commands at usrp_time %2.4f\n", get_log_time(), debugt);
     
     if (MCM_STYLE) {
         usrp->set_gpio_attr("FP0","CTRL",MANUAL_CONTROL, MCM_SYNC);
@@ -204,13 +204,13 @@ void init_timing_signals(
        if (mimic_active) {
            usrp->set_gpio_attr("TXA","CTRL",MANUAL_CONTROL,MIMIC_PINS);
            usrp->set_gpio_attr("TXA","DDR" ,MIMIC_PINS, MIMIC_PINS);
-           DEBUG_PRINT("DIO.cpp: init MIMIC target\n");
+           DEBUG_PRINT("%s: DIO.cpp: init MIMIC target\n", get_log_time());
        }
     }
 
 
     debugt = usrp->get_time_now().get_real_secs();
-    DEBUG_PRINT("DIO: set gpio attrs at usrp_time %2.4f\n", debugt);
+    DEBUG_PRINT("%s: DIO: set gpio attrs at usrp_time %2.4f\n", get_log_time(), debugt);
 
 }
 
@@ -226,9 +226,9 @@ bool read_FAULT_status_from_control_board(
     char bank_name[4];
     sprintf(bank_name, "TX%c",65 + iSide);
     uint32_t input = usrp->get_gpio_attr(bank_name, "READBACK");
-    DEBUG_PRINT("Readback from control board: %d\n", input);
+    DEBUG_PRINT("%s: Readback from control board: %d\n", get_log_time(), input);
     bool notFAULT = (input & NOT_FAULT_PIN) != 0;
-    DEBUG_PRINT("Returning FAULT = %d\n", !notFAULT);
+    DEBUG_PRINT("%s: Returning FAULT = %d\n", get_log_time(), !notFAULT);
     return !notFAULT;
 }
 
@@ -337,7 +337,7 @@ void send_timing_for_sequence(
     gmt = gmtime(&current_time);
     fprintf(stderr,"GPIO command issue start time is: %s", asctime(gmt));
 
-    DEBUG_PRINT("DIO: pushed gpio commands at usrp_time %2.4f\n", debugt);
+    DEBUG_PRINT("%s: DIO: pushed gpio commands at usrp_time %2.4f\n", get_log_time(), debugt);
     // issue gpio commands in time sorted order 
     // set_command_time must be sent in temporal order, they are sent into a fifo queue on the usrp and will block until executed
     // clear_command_time does not clear or bypass the buffer as of 10/2014..
@@ -361,7 +361,7 @@ void send_timing_for_sequence(
     fprintf(stderr,"GPIO command issue end time is: %s", asctime(gmt));
 
     debugt = usrp->get_time_now().get_real_secs();
-    DEBUG_PRINT("All DIO commands sent! clock time %2.4f\n",debugt);
+    DEBUG_PRINT("%s: All DIO commands sent! clock time %2.4f\n", get_log_time(), debugt);
 
     usrp->clear_command_time();
 
@@ -401,8 +401,8 @@ void kodiak_set_rxfe(
     rxfe_dio = (~rxfe_dio) & 0xFF; // invert all, since high means amp  and att off
 
 
-    DEBUG_PRINT("DIO.cpp: received rf_settings: \n   amp1: %d\n   amp2: %d\n   att 0.5 dB: %d\n   att 1 dB  : %d\n   att 2 dB  : %d\n   att 4 dB  : %d\n   att 8 dB  : %d\n   att 16 dB : %d\n", rf_settings.amp1, rf_settings.amp2, rf_settings.att_05_dB, rf_settings.att_1_dB, rf_settings.att_2_dB, rf_settings.att_4_dB, rf_settings.att_8_dB, rf_settings.att_16_dB );
-    DEBUG_PRINT("DIO.cpp: sending rxfe_dio:  %d\n", rxfe_dio);
+    DEBUG_PRINT("%s: DIO.cpp: received rf_settings: \n   amp1: %d\n   amp2: %d\n   att 0.5 dB: %d\n   att 1 dB  : %d\n   att 2 dB  : %d\n   att 4 dB  : %d\n   att 8 dB  : %d\n   att 16 dB : %d\n", get_log_time(), rf_settings.amp1, rf_settings.amp2, rf_settings.att_05_dB, rf_settings.att_1_dB, rf_settings.att_2_dB, rf_settings.att_4_dB, rf_settings.att_8_dB, rf_settings.att_16_dB );
+    DEBUG_PRINT("%s: DIO.cpp: sending rxfe_dio:  %d\n", get_log_time(), rxfe_dio);
 
     usrp->set_gpio_attr("RXA", "OUT", rxfe_dio, RXFE_MASK);
     if (nSides ==2) {

--- a/usrp_driver/rx_worker.cpp
+++ b/usrp_driver/rx_worker.cpp
@@ -59,7 +59,7 @@ void usrp_rx_worker(
 
     uhd::time_spec_t rx_usrp_pre_stream_time = usrp->get_time_now();
     if(offset_time_spec(start_time, RX_OFFSET) - rx_usrp_pre_stream_time.get_real_secs() < RX_STREAM_EXEC_TIME) {
-        fprintf(stderr, "Error in rx_worker: not enough time before start of stream, skipping this integration period..");
+        fprintf(stderr, "Error in rx_worker: not enough time before start of stream, skipping this integration period..\n");
         *return_status= RX_WORKER_STREAM_TIME_ERROR;
         return;
     }

--- a/usrp_driver/rx_worker.cpp
+++ b/usrp_driver/rx_worker.cpp
@@ -50,7 +50,7 @@ void usrp_rx_worker(
     uhd::set_thread_priority_safe(priority,realtime);
 
     float debugt = usrp->get_time_now().get_real_secs();
-    DEBUG_PRINT("entering RX_WORKER %2.4f\n",debugt);
+    DEBUG_PRINT("%s: entering RX_WORKER %2.4f\n", get_log_time(), debugt);
  //   fprintf( stderr, "RX WORKER nSamples requested: %i\n", num_requested_samps );
  //   fprintf( stderr, "RX WORKER nSides : %i\n", nSides );
 
@@ -93,7 +93,7 @@ void usrp_rx_worker(
     rx_usrp_pre_stream_time = usrp->get_time_now();
     time_to_start = start_time.get_real_secs() - rx_usrp_pre_stream_time.get_real_secs();
     fprintf(stderr,"#timing: time left for rx_worker  %f ms\n", time_to_start*1000);
-    DEBUG_PRINT("rx_worker: samples_remaining_to stream: %ld  max_samples_per_stream: %ld\n",samples_remaining_to_stream,max_samples_per_stream);
+    DEBUG_PRINT("%s: rx_worker: samples_remaining_to stream: %ld  max_samples_per_stream: %ld\n", get_log_time(), samples_remaining_to_stream,max_samples_per_stream);
 
 
     //int counter=0;
@@ -106,11 +106,11 @@ void usrp_rx_worker(
        
         // issue the first stream command to be timed at the start of the integration period
 	debugt = usrp->get_time_now().get_real_secs();
-	DEBUG_PRINT("RX_WORKER: before stream command %2.4f\n",debugt);
+	DEBUG_PRINT("%s: RX_WORKER: before stream command %2.4f\n", get_log_time(), debugt);
         stream_cmd.stream_now = false;
         usrp->issue_stream_cmd(stream_cmd); 
 	debugt = usrp->get_time_now().get_real_secs();
-	DEBUG_PRINT("RX_WORKER: issued stream command %2.4f\n",debugt);//,++counter);
+	DEBUG_PRINT("%s: RX_WORKER: issued stream command %2.4f\n", get_log_time(), debugt);//,++counter);
 
         samples_remaining_to_stream -= max_samples_per_stream;
 
@@ -122,7 +122,7 @@ void usrp_rx_worker(
             samples_remaining_to_stream -= max_samples_per_stream;
 	    usleep(usecs);
 	    debugt = usrp->get_time_now().get_real_secs();
-	    DEBUG_PRINT("RX_WORKER: issued stream command %2.4f\n",debugt);//,++counter);
+	    DEBUG_PRINT("%s: RX_WORKER: issued stream command %2.4f\n", get_log_time(), debugt);//,++counter);
         }
         
         // finally, issue a NUM_SAMPS_AND_DONE command for the last command
@@ -132,7 +132,7 @@ void usrp_rx_worker(
         usrp->issue_stream_cmd(stream_cmd); 
 	usleep(usecs);
 	debugt = usrp->get_time_now().get_real_secs();
-	DEBUG_PRINT("RX_WORKER: issued last stream command %2.4f\n",debugt);//,++counter);
+	DEBUG_PRINT("%s: RX_WORKER: issued last stream command %2.4f\n", get_log_time(), debugt);//,++counter);
     }
     
     else {
@@ -156,14 +156,14 @@ void usrp_rx_worker(
     }
  */
     debugt = usrp->get_time_now().get_real_secs();
-    DEBUG_PRINT("starting rx_worker while loop %2.4f\n",debugt);
+    DEBUG_PRINT("%s: starting rx_worker while loop %2.4f\n", get_log_time(), debugt);
     while(num_acc_samps < num_requested_samps) {
 
         size_t samp_request = std::min(max_samples_per_packet, num_requested_samps - num_acc_samps);
         for (int iSide = 0; iSide < nSides; iSide++) {
             buff_ptrs[iSide] = &((*rx_data_buffer)[iSide][num_acc_samps]);
             if (num_acc_samps == 0)
-               DEBUG_PRINT("rx_worker addr: %p iSide: %d \n    ", buff_ptrs[iSide], iSide);
+               DEBUG_PRINT("%s: rx_worker addr: %p iSide: %d\n", get_log_time(), buff_ptrs[iSide], iSide);
         }
 
         size_t num_rx_samps = rx_stream->recv(buff_ptrs , samp_request, md, timeout);
@@ -201,7 +201,7 @@ void usrp_rx_worker(
         num_acc_samps += num_rx_samps;
     }
     debugt = usrp->get_time_now().get_real_secs();
-    DEBUG_PRINT("RX_WORKER fetched samples! %2.4f\n",debugt);
+    DEBUG_PRINT("%s:     RX_WORKER fetched samples! %2.4f\n", get_log_time(), debugt);
 //    if(DEBUG) std::cout << boost::format("RX_WORKER : %u full secs, %f frac secs") % md.time_spec.get_full_secs() % md.time_spec.get_frac_secs() << std::endl;
 
     if (num_acc_samps != num_requested_samps){
@@ -263,7 +263,7 @@ void usrp_rx_worker(
     }
 */
 
-    DEBUG_PRINT("RX_WORKER finished\n");
+    DEBUG_PRINT("%s: RX_WORKER finished\n", get_log_time());
     return;
 }
 

--- a/usrp_driver/tx_worker.cpp
+++ b/usrp_driver/tx_worker.cpp
@@ -12,6 +12,7 @@
 #include <time.h>
 
 #include "tx_worker.h"
+#include "usrp_utils.h"
 
 #define TEST_TXWORKER 0
 #define SAVE_TX_SAMPLES_DEBUG 0
@@ -44,7 +45,7 @@ void usrp_tx_worker(
     gettimeofday(&t0,NULL);
 
     fprintf(stderr,"TX_WORKER starting up\n");
-    DEBUG_PRINT("TX_WORKER starting up\n");
+    DEBUG_PRINT("%s: TX_WORKER starting up\n", get_log_time());
 
     float priority=1;
     bool realtime=true;
@@ -61,11 +62,11 @@ void usrp_tx_worker(
     size_t spb = tx_stream->get_max_num_samps();
     int32_t samples_per_pulse = padded_num_samples_per_pulse - 2*spb; 
     fprintf(stderr,"TX_WORKER nSamples_per_pulse=%i + 2*%zu (zero padding)\n", samples_per_pulse, spb);
-    DEBUG_PRINT("TX_WORKER nSamples_per_pulse=%i + 2*%zu (zero padding)\n", samples_per_pulse, spb);
+    DEBUG_PRINT("%s: TX_WORKER nSamples_per_pulse=%i + 2*%zu (zero padding)\n", get_log_time(), samples_per_pulse, spb);
     int iSide;
     int nSides = pulse_samples.size();
     std::vector<std::complex<int16_t>*> buffer(nSides); 
-    DEBUG_PRINT("TX_WORKER nSides=%i\n", nSides);
+    DEBUG_PRINT("%s: TX_WORKER nSides=%i\n", get_log_time(), nSides);
 
     // assume at least spb length zero padding before first pulse
     size_t tx_burst_length_samples = pulse_sample_idx_offsets[number_of_pulses-1] + samples_per_pulse -1;
@@ -115,12 +116,12 @@ void usrp_tx_worker(
     //    if(DEBUG && sample_idx) std::cout << boost::format(" Sent packet:  idx: %i") % sample_idx << std::endl;
         nacc_samples += ntx_samples;
     }
-    DEBUG_PRINT("TX_WORKER tx_burst_length_samples=%li\n", tx_burst_length_samples );
+    DEBUG_PRINT("%s: TX_WORKER tx_burst_length_samples=%li\n", get_log_time(), tx_burst_length_samples);
 
     md.end_of_burst = true;
     tx_stream->send(&pulse_samples[0], 0, md, timeout);
 
-    DEBUG_PRINT("Waiting for async burst ACK... ");
+    DEBUG_PRINT("%s: Waiting for async burst ACK... ", get_log_time());
     uhd::async_metadata_t async_md;
     bool got_async_burst_ack = false;
 
@@ -130,12 +131,12 @@ void usrp_tx_worker(
     
     DEBUG_PRINT((got_async_burst_ack ? "success\n" : "fail\n"));
 
-    DEBUG_PRINT("TX_WORKER finished pulses\n");
+    DEBUG_PRINT("%s: TX_WORKER finished pulses\n", get_log_time());
 
     gettimeofday(&t1,NULL);
     double elapsed=(t1.tv_sec-t0.tv_sec)*1E6;
     elapsed+=(t1.tv_usec-t0.tv_usec);
     std::cout << "finished transmitting pulse sequence, elapsed tx worker time (us): " << elapsed << "\n";
-    DEBUG_PRINT("TX_WORKER finished\n");
+    DEBUG_PRINT("%s: TX_WORKER finished\n", get_log_time());
  
 }

--- a/usrp_driver/usrp_driver.cpp
+++ b/usrp_driver/usrp_driver.cpp
@@ -435,6 +435,7 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
 
     uhd::time_spec_t start_time, rx_start_time;
     uhd::usrp_clock::multi_usrp_clock::sptr gps_clock;
+    std::vector<std::string> sensor_names;
 
     // vector of all pulse start times over an integration period
     std::vector<uhd::time_spec_t> pulse_time_offsets;
@@ -641,10 +642,15 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
                 DEBUG_PRINT("%s: Clock is using an internal reference (good!)\n", get_log_time());
             }
 
-            if (gps_clock->get_sensor("gps_locked").value == "false") {
-                DEBUG_PRINT("%s: GPS is not locked.\n", get_log_time());
+            sensor_names = gps_clock->get_sensor_names(0);
+            if (std::find(sensor_names.begin(), sensor_names.end(), "gps_locked") == sensor_names.end()) {
+                DEBUG_PRINT("%s: gps_locked sensor not found on clock.\n", get_log_time());
             } else {
-                DEBUG_PRINT("%s: GPS is locked.\n", get_log_time());
+                if (gps_clock->get_sensor("gps_locked").value == "false") {
+                    DEBUG_PRINT("%s: GPS is not locked.\n", get_log_time());
+                } else {
+                    DEBUG_PRINT("%s: GPS is locked.\n", get_log_time());
+                }
             }
 
             // This while loop doesn't work because of the USRP sock timeout

--- a/usrp_driver/usrp_driver.cpp
+++ b/usrp_driver/usrp_driver.cpp
@@ -32,6 +32,7 @@
 #include <uhd/utils/thread.hpp>
 #include <uhd/utils/safe_main.hpp>
 #include <uhd/usrp/multi_usrp.hpp>
+#include <uhd/usrp_clock/multi_usrp_clock.hpp>
 #include <uhd/transport/udp_simple.hpp>
 #include <uhd/exception.hpp>
 
@@ -432,6 +433,7 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
     uint32_t tx_worker_active;
 
     uhd::time_spec_t start_time, rx_start_time;
+    uhd::usrp_clock::multi_usrp_clock::sptr gps_clock;
 
     // vector of all pulse start times over an integration period
     std::vector<uhd::time_spec_t> pulse_time_offsets;
@@ -454,7 +456,10 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
     txshm_size = std::stoi(pt.get<std::string>("shm_settings.txshm_size"));
 
     usrp_driver_base_port = std::stoi(pt.get<std::string>("network_settings.USRPDriverPort"));
-    
+
+    std::string addr = "addr=" + pt.get<std::string>("network_settings.GPSOctoclockHostname");
+    const char *clk_addr = addr.c_str();
+
     boost::property_tree::ptree pt_array;
     DEBUG_PRINT("%s: USRP_DRIVER starting to read array_config.ini\n", get_log_time());
     boost::property_tree::ini_parser::read_ini("../array_config.ini", pt_array);
@@ -619,6 +624,26 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
     else {
     // sync clock with external 10 MHz and PPS
         DEBUG_PRINT("%s: Set clock: external\n", get_log_time());
+        gps_clock = uhd::usrp_clock::multi_usrp_clock::make(uhd::device_addr_t(clk_addr));
+
+        if (gps_clock->get_sensor("gps_detected").value == "false") {
+            DEBUG_PRINT("%s: No GPSDO detected on clock.", get_log_time());
+        } else {
+            DEBUG_PRINT("%s: GPSDO detected on clock.\n", get_log_time());
+        }
+
+        if (gps_clock->get_sensor("using_ref").value != "internal") {
+            DEBUG_PRINT("%s: Clock is not using an internal reference (bad!)\n", get_log_time());
+        } else {
+            DEBUG_PRINT("%s: Clock is using an internal reference (good!)\n", get_log_time());
+        }
+
+        while (!(gps_clock->get_sensor("gps_locked").to_bool())) {
+            std::this_thread::sleep_for(std::chrono::seconds(2));
+            DEBUG_PRINT("%s: Waiting for gps lock...\n", get_log_time());
+        }
+        DEBUG_PRINT("%s: GPS is locked.\n", get_log_time());
+
         usrp->set_clock_source("external", 0);
         DEBUG_PRINT("%s: Set time: external\n", get_log_time());
         usrp->set_time_source("external", 0);
@@ -1053,9 +1078,37 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
                         usrp->set_time_next_pps(uhd::time_spec_t(0.0));
                         boost::this_thread::sleep(boost::posix_time::milliseconds(1100));
                  */
-                        DEBUG_PRINT("%s: Start setting unknown pps\n", get_log_time());
-                        usrp->set_time_unknown_pps(uhd::time_spec_t(11.0));
-                        DEBUG_PRINT("%s: end setting unknown pps\n", get_log_time());
+                        //DEBUG_PRINT("%s: Start setting unknown pps\n", get_log_time());
+                        //usrp->set_time_unknown_pps(uhd::time_spec_t(11.0));
+                        //DEBUG_PRINT("%s: end setting unknown pps\n", get_log_time());
+
+                        auto wait_for_update = [&]() {
+                            uhd::time_spec_t last = usrp->get_time_last_pps();
+                            uhd::time_spec_t next = usrp->get_time_last_pps();
+                            while (next == last) {
+                                std::this_thread::sleep_for(std::chrono::milliseconds(50));
+                                last = next;
+                                next = usrp->get_time_last_pps();
+                            }
+                            std::this_thread::sleep_for(std::chrono::milliseconds(200));
+                        };
+
+                        DEBUG_PRINT("%s: Starting sync to PPS.\n", get_log_time());
+                        wait_for_update();
+                        usrp->set_time_next_pps(uhd::time_spec_t(static_cast<double>(gps_clock->get_time() + 1)));
+                        wait_for_update();
+                        DEBUG_PRINT("%s: Finished sync to PPS.\n", get_log_time());
+
+                        auto clock_time = uhd::time_spec_t(static_cast<double>(gps_clock->get_time()));
+
+                        for (uint32_t board=0; board < usrp->get_num_mboards(); board++) {
+                            auto usrp_time = usrp->get_time_last_pps(board);
+                            auto time_diff = clock_time - usrp_time;
+
+                            DEBUG_PRINT("%s: Time difference between USRPs and gps clock for board %d is %f\n",
+                                        get_log_time(), board, time_diff.get_real_secs());
+                        }
+
                      }
 
                     sock_send_uint8(driverconn, UHD_SYNC);

--- a/usrp_driver/usrp_driver.cpp
+++ b/usrp_driver/usrp_driver.cpp
@@ -442,7 +442,7 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
     boost::thread_group clrfreq_threads;
 
     // process config file for port and SHM sizes
-    DEBUG_PRINT("USRP_DRIVER starting to read driver_config.ini\n");
+    DEBUG_PRINT("%s: USRP_DRIVER starting to read driver_config.ini\n", get_log_time());
     boost::property_tree::ptree pt;
     boost::property_tree::ini_parser::read_ini("../driver_config.ini", pt);
 
@@ -456,7 +456,7 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
     usrp_driver_base_port = std::stoi(pt.get<std::string>("network_settings.USRPDriverPort"));
     
     boost::property_tree::ptree pt_array;
-    DEBUG_PRINT("USRP_DRIVER starting to read array_config.ini\n");
+    DEBUG_PRINT("%s: USRP_DRIVER starting to read array_config.ini\n", get_log_time());
     boost::property_tree::ini_parser::read_ini("../array_config.ini", pt_array);
     mimic_active = std::stof(pt_array.get<std::string>("mimic.mimic_active")) != 0;
     mimic_delay  = std::stof(pt_array.get<std::string>("mimic.mimic_delay"));
@@ -480,7 +480,7 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
     double txrate, rxrate, txfreq, rxfreq;
     double txrate_new, rxrate_new, txfreq_new, rxfreq_new;
 
-    DEBUG_PRINT("usrp_driver debug mode enabled\n");
+    DEBUG_PRINT("%s: usrp_driver debug mode enabled\n", get_log_time());
 
     nerrors = arg_parse(argc,argv,argtable);
     if (nerrors > 0) {
@@ -514,25 +514,25 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
     std::vector<uint64_t> channel_numbers;
     // both sides
     if( nSides == 2 ) {
-        DEBUG_PRINT("Setting side A: ant_idx %d\n",ai_ant_a->ival[0]);
+        DEBUG_PRINT("%s: Setting side A: ant_idx %d\n",get_log_time(), ai_ant_a->ival[0]);
         antennaVector[0] = ai_ant_a->ival[0];
         channel_numbers.push_back(0);
 
-        DEBUG_PRINT("Setting side B: ant_idx %d\n",ai_ant_b->ival[0]);
+        DEBUG_PRINT("%s: Setting side B: ant_idx %d\n", get_log_time(), ai_ant_b->ival[0]);
         antennaVector[1] = ai_ant_b->ival[0];
         channel_numbers.push_back(1);
     } else {
      // side A
      if (ai_ant_a->count == 1) {
-        DEBUG_PRINT("Setting side A: ant_idx %d\n",ai_ant_a->ival[0]);
+        DEBUG_PRINT("%s: Setting side A: ant_idx %d\n", get_log_time(), ai_ant_a->ival[0]);
         antennaVector[0] = ai_ant_a->ival[0];
         channel_numbers.push_back(0);
      // side B
      } else {
-        DEBUG_PRINT("Setting side B: ant_idx %d\n",ai_ant_b->ival[0]);
+        DEBUG_PRINT("%s: Setting side B: ant_idx %d\n", get_log_time(), ai_ant_b->ival[0]);
         antennaVector[0] = ai_ant_b->ival[0];
         channel_numbers.push_back(1);
-        DEBUG_PRINT("Warning: For one side use DIO output is always on Side A!!!!!!!!!!!!!"); // TODO correct this
+        DEBUG_PRINT("%s: Warning: For one side use DIO output is always on Side A!!!!!!!!!!!!!", get_log_time()); // TODO correct this
 
 
      }
@@ -561,7 +561,7 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
     uhd::stream_args_t stream_args("sc16", "sc16");
     
     if (usrp->get_rx_num_channels() < nSides || usrp->get_tx_num_channels() < nSides) {  
-       DEBUG_PRINT("ERROR: Number of defined channels (%i) is smaller than avaialable channels:\n    usrp->get_rx_num_channels(): %lu \n    usrp->get_tx_num_channels(): %lu \n\n", nSides, usrp->get_rx_num_channels(),   usrp->get_tx_num_channels());
+       DEBUG_PRINT("%s: ERROR: Number of defined channels (%i) is smaller than avaialable channels:\n    usrp->get_rx_num_channels(): %lu \n    usrp->get_tx_num_channels(): %lu \n\n", get_log_time(), nSides, usrp->get_rx_num_channels(),   usrp->get_tx_num_channels());
        return -1;
     }
     stream_args.channels = channel_numbers;
@@ -596,7 +596,7 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
             int shm_side = 0;
             shm_rx_vec[iSide][iSwing] = open_sample_shm(antennaVector[iSide], RXDIR, shm_side, iSwing, rxshm_size);
             shm_tx_vec[iSide][iSwing] = open_sample_shm(antennaVector[iSide], TXDIR, shm_side, iSwing, txshm_size);
-            DEBUG_PRINT("usrp_driver rx shm addr: %p iSide: %d iSwing: %d\n", shm_rx_vec[iSide][iSwing], iSide, iSwing);
+            DEBUG_PRINT("%s: usrp_driver rx shm addr: %p iSide: %d iSwing: %d\n", get_log_time(), shm_rx_vec[iSide][iSwing], iSide, iSwing);
 
             if (antennaVector[iSide] < 19 ) { // semaphores only for antennas of first polarization TODO check if this is enough
                sem_rx_vec[iSwing] = open_sample_semaphore(antennaVector[iSide], iSwing, RXDIR);
@@ -606,7 +606,7 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
     }
 
     if(al_interferometer->count > 0) {
-       DEBUG_PRINT("Disable tx_worker ...\n");
+       DEBUG_PRINT("%s: Disable tx_worker ...\n", get_log_time());
        tx_worker_active = 0;
     } else {
        tx_worker_active = 1;
@@ -618,11 +618,11 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
     }
     else {
     // sync clock with external 10 MHz and PPS
-        DEBUG_PRINT("Set clock: external\n");
+        DEBUG_PRINT("%s: Set clock: external\n", get_log_time());
         usrp->set_clock_source("external", 0);
-        DEBUG_PRINT("Set time: external\n");
+        DEBUG_PRINT("%s: Set time: external\n", get_log_time());
         usrp->set_time_source("external", 0);
-        DEBUG_PRINT("Done setting time and clock\n");
+        DEBUG_PRINT("%s: Done setting time and clock\n", get_log_time());
      }
 
     while(true) {
@@ -672,13 +672,13 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
         while(true) {
             // wait for transport endpoint to connect?
             
-            DEBUG_PRINT("USRP_DRIVER waiting for command\n");
+            DEBUG_PRINT("%s: USRP_DRIVER waiting for command\n", get_log_time());
             uint8_t command = sock_get_cmd(driverconn, &cmd_status);
-            DEBUG_PRINT("USRP_DRIVER received command, status: %zu\n", cmd_status);
+            DEBUG_PRINT("%s: USRP_DRIVER received command, status: %zu\n", get_log_time(), cmd_status);
              
             // see if socket is closed..
             if(cmd_status == 11 || cmd_status == 0 || cmd_status < 0) {
-                DEBUG_PRINT("USRP_DRIVER lost connection to usrp_server, waiting for fresh connection, %d tries remaining\n", connect_retrys);
+                DEBUG_PRINT("%s: USRP_DRIVER lost connection to usrp_server, waiting for fresh connection, %d tries remaining\n", get_log_time(), connect_retrys);
                 close(driversock);
                 if(connect_retrys-- < 0) {
                     exit(1);
@@ -699,7 +699,7 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
                     
                     swing      = sock_get_int16(  driverconn); 
                     
-                    DEBUG_PRINT("entering USRP_SETUP command (swing %d)\n", swing);
+                    DEBUG_PRINT("%s: entering USRP_SETUP command (swing %d)\n", get_log_time(), swing);
                   
                     txfreq_new = sock_get_float64(driverconn);
                     rxfreq_new = sock_get_float64(driverconn);
@@ -714,10 +714,10 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
                     nSamples_tx_pulse        = sock_get_uint64(driverconn);
                     nSamples_rx_total        = nSamples_rx + nSamples_pause_after_rx + nSamples_auto_clear_freq;
 
-                    DEBUG_PRINT("USRP_SETUP number of requested rx samples: %d + %ld pause + %ld auto clear freq\n", (uint32_t) nSamples_rx, nSamples_pause_after_rx, nSamples_auto_clear_freq);
-                    DEBUG_PRINT("USRP_SETUP number of requested tx samples per pulse: %d\n", (uint32_t) nSamples_tx_pulse);
-                    DEBUG_PRINT("USRP_SETUP existing tx rate : %f (swing %d)\n", txrate, swing);
-                    DEBUG_PRINT("USRP_SETUP requested tx rate: %f\n", txrate_new);
+                    DEBUG_PRINT("%s: USRP_SETUP number of requested rx samples: %d + %ld pause + %ld auto clear freq\n", get_log_time(), (uint32_t) nSamples_rx, nSamples_pause_after_rx, nSamples_auto_clear_freq);
+                    DEBUG_PRINT("%s: USRP_SETUP number of requested tx samples per pulse: %d\n", get_log_time(), (uint32_t) nSamples_tx_pulse);
+                    DEBUG_PRINT("%s: USRP_SETUP existing tx rate : %f (swing %d)\n", get_log_time(), txrate, swing);
+                    DEBUG_PRINT("%s: USRP_SETUP requested tx rate: %f\n", get_log_time(), txrate_new);
 
                     // resize 
                     pulse_sample_idx_offsets.resize(npulses);
@@ -729,7 +729,7 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
                 //        DEBUG_PRINT("USRP_SETUP received %zu pulse offset\n", pulse_sample_idx_offsets[i]);
 
                     }
-                    DEBUG_PRINT("USRP_SETUP resize autoclear freq\n");
+                    DEBUG_PRINT("%s: USRP_SETUP resize autoclear freq\n", get_log_time());
 
                     // RESIZE LOCAL BUFFERS
                     if(rx_data_buffer[0].size() < nSamples_rx_total) {
@@ -737,7 +737,7 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
                            rx_data_buffer[iSide].resize(nSamples_rx_total);
                        }
                     }
-                    DEBUG_PRINT("USRP_SETUP resize autoclear freq\n");
+                    DEBUG_PRINT("%s: USRP_SETUP resize autoclear freq\n", get_log_time());
 
                     if(nSamples_auto_clear_freq != 0 and rx_auto_clear_freq[0].size() < nSamples_auto_clear_freq) {
                        for(iSide = 0; iSide < nSides; iSide++) {
@@ -815,13 +815,13 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
 
 
                     state_vec[swing] = ST_READY; 
-                    DEBUG_PRINT("changing state_vec[swing] to ST_READY\n");
+                    DEBUG_PRINT("%s: changing state_vec[%d] to ST_READY\n", get_log_time(), swing);
                     sock_send_uint8(driverconn, USRP_SETUP);
                     break;
                     }
 
                 case RXFE_SET: {
-                    DEBUG_PRINT("entering RXFE_SET command\n");
+                    DEBUG_PRINT("%s: entering RXFE_SET command\n", get_log_time());
                     RXFESettings rf_settings;
                     rf_settings.amp1 = sock_get_uint8(driverconn);
                     rf_settings.amp2 = sock_get_uint8(driverconn);
@@ -842,29 +842,29 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
                 case TRIGGER_PULSE: {
 
                     swing      = sock_get_int16(  driverconn); 
-                    DEBUG_PRINT("entering TRIGGER_PULSE command (swing %d)\n", swing );
+                    DEBUG_PRINT("%s: entering TRIGGER_PULSE command (swing %d)\n", get_log_time(), swing);
 
                     if (state_vec[swing] != ST_READY) {
                         sock_send_uint8(driverconn, TRIGGER_BUSY);
-                        DEBUG_PRINT("TRIGGER_PULSE busy in state_vec[swing] %d, returning\n", state_vec[swing]);
+                        DEBUG_PRINT("%s: TRIGGER_PULSE busy in state_vec[%d] %d, returning\n", get_log_time(), swing, state_vec[swing]);
                     }
                     else {
 
-                        DEBUG_PRINT("TRIGGER_PULSE ready\n");
+                        DEBUG_PRINT("%s: TRIGGER_PULSE ready\n", get_log_time());
                         state_vec[swing] = ST_PULSE;
 
-                        DEBUG_PRINT("TRIGGER_PULSE locking semaphore\n");
+                        DEBUG_PRINT("%s: TRIGGER_PULSE locking semaphore\n", get_log_time());
                         lock_semaphore(sem_rx_vec[swing]); 
                         lock_semaphore(sem_tx_vec[swing]); 
 
-                        DEBUG_PRINT("TRIGGER_PULSE semaphore locked\n");
+                        DEBUG_PRINT("%s: TRIGGER_PULSE semaphore locked\n", get_log_time());
 
                         // create local copy of transmit pulse data from shared memory
                         size_t spb = tx_stream->get_max_num_samps();
                         size_t pulse_bytes = sizeof(std::complex<int16_t>) * nSamples_tx_pulse;
                         size_t number_of_pulses = pulse_time_offsets.size();
                         size_t num_samples_per_pulse_with_padding = nSamples_tx_pulse + 2*spb;
-                        DEBUG_PRINT("spb %ld, pulse length %ld samples, pulse with padding %ld\n", spb, nSamples_tx_pulse, num_samples_per_pulse_with_padding);
+                        DEBUG_PRINT("%s: spb %ld, pulse length %ld samples, pulse with padding %ld\n", get_log_time(), spb, nSamples_tx_pulse, num_samples_per_pulse_with_padding);
 
 
                         // read in time for start of pulse sequence over socket
@@ -883,7 +883,7 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
 			  // DEBUG_PRINT("TRIGGER_PULSE pulse time %d is %2.5lf offset is %2.5lf\n", p_i, pulse_time_offsets[p_i].get_real_secs()- pulse_time_offsets[0].get_real_secs(),(double)pulse_sample_idx_offsets[p_i]/(double)txrate-(double)pulse_sample_idx_offsets[0]/(double)txrate);
                         }
 
-                        DEBUG_PRINT("first TRIGGER_PULSE time is %2.5f and last is %2.5f\n", pulse_time_offsets[0].get_real_secs(), pulse_time_offsets.back().get_real_secs());
+                        DEBUG_PRINT("%s: first TRIGGER_PULSE time is %2.5f and last is %2.5f\n", get_log_time(), pulse_time_offsets[0].get_real_secs(), pulse_time_offsets.back().get_real_secs());
 
                         rx_start_time = offset_time_spec(start_time, tr_to_pulse_delay/1e6);
                         rx_start_time = offset_time_spec(rx_start_time, pulse_sample_idx_offsets[0]/txrate); 
@@ -894,9 +894,9 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
 			
 			
                         float debugt = usrp->get_time_now().get_real_secs();
-                        DEBUG_PRINT("USRP_DRIVER: spawning worker threads at usrp_time %2.4f\n", debugt);
+                        DEBUG_PRINT("%s: USRP_DRIVER: spawning worker threads at usrp_time %2.4f\n", get_log_time(), debugt);
 
-                        DEBUG_PRINT("TRIGGER_PULSE creating rx and tx worker threads on swing %d (nSamples_rx= %d + %ld pause + %ld auto clear freq )\n", swing,(int) nSamples_rx, nSamples_pause_after_rx, nSamples_auto_clear_freq);
+                        DEBUG_PRINT("%s: TRIGGER_PULSE creating rx and tx worker threads on swing %d (nSamples_rx= %d + %ld pause + %ld auto clear freq )\n", get_log_time(), swing,(int) nSamples_rx, nSamples_pause_after_rx, nSamples_auto_clear_freq);
                         // works fine with tx_worker and dio_worker, fails if rx_worker is enabled
                         uhd_threads.create_thread(boost::bind(usrp_rx_worker, usrp, rx_stream, &rx_data_buffer, nSamples_rx_total, rx_start_time, &rx_worker_status));
 
@@ -913,7 +913,7 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
                         sock_send_uint8(driverconn, TRIGGER_PULSE);
 
                         uhd_threads.join_all(); // wait for transmit threads to finish, drawn from shared memory..
-                        DEBUG_PRINT("TRIGGER_PULSE rx_worker, tx_worker and dio threads on swing %d\n joined.", swing);
+                        DEBUG_PRINT("%s: TRIGGER_PULSE rx_worker, tx_worker and dio threads on swing %d joined.\n", get_log_time(), swing);
 
 
                     }
@@ -924,14 +924,14 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
 
                 case READY_DATA: {
                     swing      = sock_get_int16(  driverconn); 
-                    DEBUG_PRINT("READY_DATA command (swing %d), waiting for uhd threads to join back\n", swing);
+                    DEBUG_PRINT("%s: READY_DATA command (swing %d), waiting for uhd threads to join back\n", get_log_time(), swing);
 
                     
-                    DEBUG_PRINT("READY_DATA unlocking swing a semaphore\n");
+                    DEBUG_PRINT("%s: READY_DATA unlocking swing a semaphore\n", get_log_time());
                     unlock_semaphore(sem_rx_vec[swing]);
                     unlock_semaphore(sem_tx_vec[swing]);
         
-                    DEBUG_PRINT("READY_DATA usrp worker threads joined, semaphore unlocked, sending metadata\n");
+                    DEBUG_PRINT("%s: READY_DATA usrp worker threads joined, semaphore unlocked, sending metadata\n", get_log_time());
                     // TODO: handle multiple channels of data.., use channel index to pick correct swath of memory to copy into shm
                   
                    // rx_worker_status =1; //DEBUG
@@ -963,7 +963,7 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
                       auto_clear_freq_available = 1;
                     }
     
-                    DEBUG_PRINT("READY_DATA state: %d, ant: %d, num_samples: %zu\n", state_vec[swing], antennaVector[0], nSamples_rx);
+                    DEBUG_PRINT("%s: READY_DATA state: %d, ant: %d, num_samples: %zu\n", get_log_time(), state_vec[swing], antennaVector[0], nSamples_rx);
                     sock_send_int32(driverconn, state_vec[swing]);  // send status
                     sock_send_int32(driverconn, antennaVector[0]);   // send antenna TODO do this for both antennas?
                     sock_send_int32(driverconn, nSamples_rx);     // nsamples;  send send number of samples
@@ -978,7 +978,7 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
                 
   
                     if (mute_output) {
-                       DEBUG_PRINT("READY_DATA: Filling SHM with zeros (because of rx_worker error) \n");
+                       DEBUG_PRINT("%s: READY_DATA: Filling SHM with zeros (because of rx_worker error)\n", get_log_time());
 
                        for (iSide = 0; iSide<nSides; iSide++) {
                           memset(shm_rx_vec[iSide][swing],  0, rxshm_size);
@@ -987,7 +987,7 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
                        mute_output = 0;
                     }
                     else {
-                        DEBUG_PRINT("READY_DATA starting copying rx data buffer to shared memory\n");
+                        DEBUG_PRINT("%s: READY_DATA starting copying rx data buffer to shared memory\n", get_log_time());
                         // regural rx data
                         for (iSide = 0; iSide<nSides; iSide++) {
                             // DEBUG_PRINT("usrp_drivercopy to rx shm addr: %p iSide: %d iSwing: %d\n", shm_rx_vec[iSide][swing], iSide, iSwing);
@@ -1013,17 +1013,17 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
 
                     }
 
-                    DEBUG_PRINT("READY_DATA finished copying rx data buffer to shared memory\n");
+                    DEBUG_PRINT("%s: READY_DATA finished copying rx data buffer to shared memory\n", get_log_time());
                     state_vec[swing] = ST_READY; 
-                    DEBUG_PRINT("changing state_vec[swing] to ST_READY\n");
+                    DEBUG_PRINT("%s: changing state_vec[%d] to ST_READY\n", get_log_time(), swing);
 
-                    DEBUG_PRINT("READY_DATA returning command success \n");
+                    DEBUG_PRINT("%s: READY_DATA returning command success \n", get_log_time());
                     sock_send_uint8(driverconn, READY_DATA);
                     break;
                     }
 
                 case UHD_GETTIME: {
-                    DEBUG_PRINT("entering UHD_GETTIME command\n");
+                    DEBUG_PRINT("%s: entering UHD_GETTIME command\n", get_log_time());
                     start_time = usrp->get_time_now();
 
                     uint32_t real_time = start_time.get_real_secs();
@@ -1032,13 +1032,13 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
                     sock_send_uint32(driverconn, real_time);
                     sock_send_float64(driverconn, frac_time);
 
-                    DEBUG_PRINT("UHD_GETTIME current UHD time: %d %.2f command\n", real_time, frac_time);
+                    DEBUG_PRINT("%s: UHD_GETTIME current UHD time: %d %.2f command\n", get_log_time(), real_time, frac_time);
                     sock_send_uint8(driverconn, UHD_GETTIME);
                     break;
                     }
                 // command to reset time, sync time with external PPS pulse
                 case UHD_SYNC: {
-                    DEBUG_PRINT("entering UHD_SYNC command\n");
+                    DEBUG_PRINT("%s: entering UHD_SYNC command\n", get_log_time());
                     // if --intclk flag passed to usrp_driver, set clock source as internal and do not sync time
                     if(al_intclk->count > 0) {
                         usrp->set_time_now(uhd::time_spec_t(0.0));
@@ -1053,9 +1053,9 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
                         usrp->set_time_next_pps(uhd::time_spec_t(0.0));
                         boost::this_thread::sleep(boost::posix_time::milliseconds(1100));
                  */
-                        DEBUG_PRINT("Start setting unknown pps\n");
+                        DEBUG_PRINT("%s: Start setting unknown pps\n", get_log_time());
                         usrp->set_time_unknown_pps(uhd::time_spec_t(11.0));
-                        DEBUG_PRINT("end setting unknown pps\n");
+                        DEBUG_PRINT("%s: end setting unknown pps\n", get_log_time());
                      }
 
                     sock_send_uint8(driverconn, UHD_SYNC);
@@ -1064,14 +1064,14 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
 
                 case AUTOCLRFREQ: {
                     // has to be called after GET_DATA and before USRP_SETUP
-                    DEBUG_PRINT("entering getting auto clear freq command\n");
+                    DEBUG_PRINT("%s: entering getting auto clear freq command\n", get_log_time());
 
                     if (auto_clear_freq_available) {
 
                       sock_send_int32(driverconn, (int32_t) nSides );
 
                       for( int jSide=0; jSide<(int)nSides; jSide++ ){
-                        DEBUG_PRINT("AUTOCLRFREQ samples sending %zu samples for antenna %d usrp side %d...\n", rx_auto_clear_freq[jSide].size(),antennaVector[jSide],jSide);
+                        DEBUG_PRINT("%s: AUTOCLRFREQ samples sending %zu samples for antenna %d usrp side %d...\n", get_log_time(), rx_auto_clear_freq[jSide].size(),antennaVector[jSide],jSide);
 
                         sock_send_int32(driverconn, (int32_t) antennaVector[jSide]);
                         sock_send_uint32(driverconn, (uint32_t) rx_auto_clear_freq[jSide].size());
@@ -1091,7 +1091,7 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
 
                     }
                 case CLRFREQ: {
-                    DEBUG_PRINT("entering CLRFREQ command\n");
+                    DEBUG_PRINT("%s: entering CLRFREQ command\n", get_log_time());
                     uint32_t num_clrfreq_samples = sock_get_uint32(driverconn);
                     uint32_t clrfreq_time_full   = sock_get_uint32(driverconn);
                     double clrfreq_time_frac     = sock_get_float64(driverconn);
@@ -1103,12 +1103,12 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
                     uint32_t real_time; 
                     double frac_time;
 
-                    DEBUG_PRINT("CLRFREQ time: %d . %.2f \n", clrfreq_time_full, clrfreq_time_frac);
-                    DEBUG_PRINT("CLRFREQ rate: %.2f, CLRFREQ_nsamples %d, freq: %.2f\n", clrfreq_rate, num_clrfreq_samples, clrfreq_cfreq);
+                    DEBUG_PRINT("%s: CLRFREQ time: %d . %.2f \n", get_log_time(), clrfreq_time_full, clrfreq_time_frac);
+                    DEBUG_PRINT("%s: CLRFREQ rate: %.2f, CLRFREQ_nsamples %d, freq: %.2f\n", get_log_time(), clrfreq_rate, num_clrfreq_samples, clrfreq_cfreq);
                     uhd::time_spec_t clrfreq_start_time = uhd::time_spec_t(clrfreq_time_full, clrfreq_time_frac);
                     real_time = clrfreq_start_time.get_real_secs();
                     frac_time = clrfreq_start_time.get_frac_secs();
-                    DEBUG_PRINT("CLRFREQ UHD clrfreq target time: %d %.2f \n", real_time, frac_time);
+                    DEBUG_PRINT("%s: CLRFREQ UHD clrfreq target time: %d %.2f \n", get_log_time(), real_time, frac_time);
 
 
                     // TODO: only set rate if it is different!
@@ -1117,7 +1117,7 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
                        rxrate = usrp->get_rx_rate();
                        clrfreq_rate = rxrate;
                     }
-                    DEBUG_PRINT("CLRFREQ actual rate: %.2f\n", clrfreq_rate);
+                    DEBUG_PRINT("%s: CLRFREQ actual rate: %.2f\n", get_log_time(), clrfreq_rate);
                     //clrfreq_cfreq = usrp->get_rx_freq(); 
                     //DEBUG_PRINT("CLRFREQ actual freq: %.2f\n", clrfreq_cfreq);
                     clrfreq_threads.create_thread(boost::bind(usrp_rx_worker, usrp, rx_stream, &clrfreq_data_buffer, num_clrfreq_samples, clrfreq_start_time, &clrfreq_rx_worker_status));
@@ -1141,7 +1141,7 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
 
 
                     sock_send_int32(driverconn, (int32_t) nSides);
-                    DEBUG_PRINT("CLRFREQ received samples, relaying %d samples back...\n", num_clrfreq_samples);
+                    DEBUG_PRINT("%s: CLRFREQ received samples, relaying %d samples back...\n", get_log_time(), num_clrfreq_samples);
                     for( int jSide = 0; jSide < (int) nSides; jSide++ ){
 
                       sock_send_int32(driverconn, (int32_t) antennaVector[jSide]);
@@ -1156,7 +1156,7 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
                     //    sock_send_cshort(driverconn, clrfreq_data_buffer[0][i]);
                    // }
 
-                    DEBUG_PRINT("CLRFREQ samples sent for antenna %d...\n", antennaVector[0]);
+                    DEBUG_PRINT("%s: CLRFREQ samples sent for antenna %d...\n", get_log_time(), antennaVector[0]);
                     // restore usrp rates
                     usrp->set_rx_rate(rxrate);
                     usrp->set_rx_freq(rxfreq);
@@ -1165,14 +1165,14 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
                     start_time = usrp->get_time_now();
                     real_time = start_time.get_real_secs();
                     frac_time = start_time.get_frac_secs();
-                    DEBUG_PRINT("CLRFREQ finished at UHD time: %d %.2f \n", real_time, frac_time);
+                    DEBUG_PRINT("%s: CLRFREQ finished at UHD time: %d %.2f \n", get_log_time(), real_time, frac_time);
 
                     break;
 
                     }
 
                 case EXIT: {
-                    DEBUG_PRINT("entering EXIT command\n");
+                    DEBUG_PRINT("%s: entering EXIT command\n", get_log_time());
 
                     exit_driver = 1;
                     break;
@@ -1192,7 +1192,7 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
 
             // clean exit
             if (exit_driver) {
-                DEBUG_PRINT("Shutting down driver\n");
+                DEBUG_PRINT("%s: Shutting down driver\n", get_log_time());
                 close(driverconn);
 
                 for(iSide = 0; iSide < nSides; iSide++) {

--- a/usrp_driver/usrp_driver.cpp
+++ b/usrp_driver/usrp_driver.cpp
@@ -62,8 +62,9 @@
 #define DEBUG_PRINT(...) do{ } while ( false )
 #endif
 
+#define GPS_WAIT 2   // in seconds
 #define SETUP_WAIT 1 // in seconds
-#define nSwings 2 // swings are slots in the swing buffer
+#define nSwings 2    // swings are slots in the swing buffer
 
 
 #define MAX_SOCKET_RETRYS 5
@@ -624,25 +625,36 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
     else {
     // sync clock with external 10 MHz and PPS
         DEBUG_PRINT("%s: Set clock: external\n", get_log_time());
-        gps_clock = uhd::usrp_clock::multi_usrp_clock::make(uhd::device_addr_t(clk_addr));
+        if (strcmp(clk_addr, "addr=")) {
+            gps_clock = uhd::usrp_clock::multi_usrp_clock::make(uhd::device_addr_t(clk_addr));
 
-        if (gps_clock->get_sensor("gps_detected").value == "false") {
-            DEBUG_PRINT("%s: No GPSDO detected on clock.", get_log_time());
+            if (gps_clock->get_sensor("gps_detected").value == "false") {
+                DEBUG_PRINT("%s: No GPSDO detected on clock.", get_log_time());
+            } else {
+                DEBUG_PRINT("%s: GPSDO detected on clock.\n", get_log_time());
+            }
+
+            if (gps_clock->get_sensor("using_ref").value != "internal") {
+                DEBUG_PRINT("%s: Clock is not using an internal reference (bad!)\n", get_log_time());
+            } else {
+                DEBUG_PRINT("%s: Clock is using an internal reference (good!)\n", get_log_time());
+            }
+
+            if (gps_clock->get_sensor("gps_locked").value == "false") {
+                DEBUG_PRINT("%s: GPS is not locked.\n", get_log_time());
+            } else {
+                DEBUG_PRINT("%s: GPS is locked.\n", get_log_time());
+            }
+
+            // This while loop doesn't work because of the USRP sock timeout
+            // in usrp_server, so only sync if GPS is locked
+            //while (!(gps_clock->get_sensor("gps_locked").to_bool())) {
+            //    DEBUG_PRINT("%s: Waiting for GPS lock...\n", get_log_time());
+            //    std::this_thread::sleep_for(std::chrono::seconds(GPS_WAIT));
+            //}
         } else {
-            DEBUG_PRINT("%s: GPSDO detected on clock.\n", get_log_time());
+            DEBUG_PRINT("%s: No GPS octoclock address found in driver_config.ini\n", get_log_time());
         }
-
-        if (gps_clock->get_sensor("using_ref").value != "internal") {
-            DEBUG_PRINT("%s: Clock is not using an internal reference (bad!)\n", get_log_time());
-        } else {
-            DEBUG_PRINT("%s: Clock is using an internal reference (good!)\n", get_log_time());
-        }
-
-        while (!(gps_clock->get_sensor("gps_locked").to_bool())) {
-            std::this_thread::sleep_for(std::chrono::seconds(2));
-            DEBUG_PRINT("%s: Waiting for gps lock...\n", get_log_time());
-        }
-        DEBUG_PRINT("%s: GPS is locked.\n", get_log_time());
 
         usrp->set_clock_source("external", 0);
         DEBUG_PRINT("%s: Set time: external\n", get_log_time());
@@ -1078,35 +1090,41 @@ int UHD_SAFE_MAIN(int argc, char *argv[]){
                         usrp->set_time_next_pps(uhd::time_spec_t(0.0));
                         boost::this_thread::sleep(boost::posix_time::milliseconds(1100));
                  */
-                        //DEBUG_PRINT("%s: Start setting unknown pps\n", get_log_time());
-                        //usrp->set_time_unknown_pps(uhd::time_spec_t(11.0));
-                        //DEBUG_PRINT("%s: end setting unknown pps\n", get_log_time());
 
-                        auto wait_for_update = [&]() {
-                            uhd::time_spec_t last = usrp->get_time_last_pps();
-                            uhd::time_spec_t next = usrp->get_time_last_pps();
-                            while (next == last) {
-                                std::this_thread::sleep_for(std::chrono::milliseconds(50));
-                                last = next;
-                                next = usrp->get_time_last_pps();
+                        // Sync time to the GPS Octoclock if it is available and locked
+                        if (strcmp(clk_addr, "addr=") &&
+                            gps_clock->get_sensor("gps_locked").to_bool()) {
+
+                            auto wait_for_update = [&]() {
+                                uhd::time_spec_t last = usrp->get_time_last_pps();
+                                uhd::time_spec_t next = usrp->get_time_last_pps();
+                                while (next == last) {
+                                    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+                                    last = next;
+                                    next = usrp->get_time_last_pps();
+                                }
+                                std::this_thread::sleep_for(std::chrono::milliseconds(200));
+                            };
+
+                            DEBUG_PRINT("%s: Start setting GPS-locked PPS.\n", get_log_time());
+                            wait_for_update();
+                            usrp->set_time_next_pps(uhd::time_spec_t(static_cast<double>(gps_clock->get_time() + 1)));
+                            wait_for_update();
+                            DEBUG_PRINT("%s: End setting GPS-locked PPS.\n", get_log_time());
+
+                            auto clock_time = uhd::time_spec_t(static_cast<double>(gps_clock->get_time()));
+
+                            for (uint32_t board=0; board < usrp->get_num_mboards(); board++) {
+                                auto usrp_time = usrp->get_time_last_pps(board);
+                                auto time_diff = clock_time - usrp_time;
+
+                                DEBUG_PRINT("%s: Time difference between USRPs and GPS clock for board %d is %f\n",
+                                            get_log_time(), board, time_diff.get_real_secs());
                             }
-                            std::this_thread::sleep_for(std::chrono::milliseconds(200));
-                        };
-
-                        DEBUG_PRINT("%s: Starting sync to PPS.\n", get_log_time());
-                        wait_for_update();
-                        usrp->set_time_next_pps(uhd::time_spec_t(static_cast<double>(gps_clock->get_time() + 1)));
-                        wait_for_update();
-                        DEBUG_PRINT("%s: Finished sync to PPS.\n", get_log_time());
-
-                        auto clock_time = uhd::time_spec_t(static_cast<double>(gps_clock->get_time()));
-
-                        for (uint32_t board=0; board < usrp->get_num_mboards(); board++) {
-                            auto usrp_time = usrp->get_time_last_pps(board);
-                            auto time_diff = clock_time - usrp_time;
-
-                            DEBUG_PRINT("%s: Time difference between USRPs and gps clock for board %d is %f\n",
-                                        get_log_time(), board, time_diff.get_real_secs());
+                        } else {
+                            DEBUG_PRINT("%s: Start setting unknown pps\n", get_log_time());
+                            usrp->set_time_unknown_pps(uhd::time_spec_t(11.0));
+                            DEBUG_PRINT("%s: End setting unknown pps\n", get_log_time());
                         }
 
                      }

--- a/usrp_driver/usrp_driver.cpp
+++ b/usrp_driver/usrp_driver.cpp
@@ -253,7 +253,7 @@ ssize_t sock_send_cshort(int32_t sock, std::complex<short int> d)
 {
    ssize_t status = send(sock, &d, sizeof(std::complex<short int>), 0);
    if(status != sizeof(std::complex<short int>)) {
-        fprintf(stderr, "error sending compelx short\n");
+        fprintf(stderr, "error sending complex short\n");
    }
    return status;
 }

--- a/usrp_driver/usrp_utils.cpp
+++ b/usrp_driver/usrp_utils.cpp
@@ -19,6 +19,24 @@
  
 #include <cstdlib>
 
+char tstr[128];
+
+char *get_log_time() {
+    struct tm *gmt;
+    struct timespec err_tm;
+    int stat;
+
+    stat = clock_gettime(CLOCK_REALTIME, &err_tm);
+
+    gmt = gmtime(&err_tm.tv_sec);
+    sprintf(tstr, "%04d-%02d-%02d %02d:%02d:%02d.%03d",
+            1900+gmt->tm_year, gmt->tm_mon+1, gmt->tm_mday,
+            gmt->tm_hour, gmt->tm_min, gmt->tm_sec,
+            (int)(err_tm.tv_nsec/1e6));
+
+    return tstr;
+}
+
 //
 void touch_file(const std::string& fileName)
 {

--- a/usrp_driver/usrp_utils.h
+++ b/usrp_driver/usrp_utils.h
@@ -1,1 +1,2 @@
+char *get_log_time();
 uhd::time_spec_t offset_time_spec(uhd::time_spec_t t0, double toffset);


### PR DESCRIPTION
This pull request adds the capability for GPS time synchronization in the usrp_driver (using a GPS Octoclock), as well as time stamps to the usrp_driver log files.  The time and PPS will be GPS synced if a GPS Octoclock is found at the address listed in the driver_config file and if a GPS signal lock has been obtained.  Otherwise, the original method of syncing to an unknown PPS will be used.

For radars that do not have a GPS Octoclock connected to the network and a GPS antenna, the GPSOctoclockHostname field in the driver_config.ini file can be left blank (currently the default).

(Note there may be a small merge conflict in the driver_confg files depending on when #2 is merged)