### PR TITLE
Adding CFS support for independent USRP mixing frequencies at each radar

### DIFF
--- a/c_include/clear_frequency_server.c
+++ b/c_include/clear_frequency_server.c
@@ -1408,6 +1408,13 @@ int main() {
                 log_debug("    sample_sep: %d", sample_sep);
             }
 
+            // Read Center Frequency
+            if (*(int*) (fcenter_obj.shm_ptr) != 0) {
+                log_debug( "Freq Center reading...");
+                read_single_int( &(meta_data.usrp_fcenter), fcenter_obj.shm_ptr);
+                log_debug("    fcenter: %d", meta_data.usrp_fcenter);
+            }
+
             // Read Radar ID
             if (*(int*) (radar_id_obj.shm_ptr) >= 0) {
                 log_debug( "Radar ID reading...");

--- a/usrp_server/usrp_server.py
+++ b/usrp_server/usrp_server.py
@@ -1245,7 +1245,7 @@ class ClearFrequencyService():
 
         return 
 
-    def request_clr_freq(self, radar_id, channel_id, beam_num=None, sample_sep=None, clr_range=None, ):
+    def request_clr_freq(self, radar_id, channel_id, beam_num=None, sample_sep=None, clr_range=None, fcenter=None):
         """ Waits for client requests, then processes server data, writes client 
             data, and requests server to process new data. When process is 
             terminated, the try/finally block cleans up.\
@@ -1254,8 +1254,9 @@ class ClearFrequencyService():
         """
 
         input_data = [
+            fcenter,
             clr_range,
-            beam_num, 
+            beam_num,
             sample_sep,
         ]
 
@@ -1280,12 +1281,12 @@ class ClearFrequencyService():
             self.sl_clrfreq['sem'].acquire()
             print("[clearFrequencyService] ClrFreq Semaphore Acquired...")
 
-            for i in range(self.SAMPLE_PARAM_NUM, self.SAMPLE_PARAM_NUM + 3):
-                
+            for i in range(self.SAMPLE_PARAM_NUM-1, self.SAMPLE_PARAM_NUM + 3):
+
                 # If data present, write to SHM
-                if input_data[i - self.SAMPLE_PARAM_NUM] is not None:
+                if input_data[i - 1] is not None:
                     print(f"[Frequency Client] Data Write: {self.shm_objects[i]['name']}")
-                    self.write_data(self.shm_objects[i], input_data[i - self.SAMPLE_PARAM_NUM])
+                    self.write_data(self.shm_objects[i], input_data[i - 1])
 
             # Write Radar ID
             print(f"[Frequency Client] Data Write: {self.shm_objects[10]['name']}")
@@ -1739,7 +1740,7 @@ class scanManager():
         if len(rawData) != len(metaData['antenna_list']):
             self.logger.error("Mismatch in number of ant samples and ant length. len(rawData)= {} antenna_list: {}".format(len(rawData),metaData['antenna_list']))
         self.logger.debug(f"antenna sample sets: {len(rawData)}   antennas: {metaData['antenna_list']}")
-        clearFreq, noise = self.clearFreqService.request_clr_freq(int(jrad), int(cnum), int(beamNo), int(self.channel.raw_export_data['smsep']), clear_freq_range)
+        clearFreq, noise = self.clearFreqService.request_clr_freq(int(jrad), int(cnum), int(beamNo), int(self.channel.raw_export_data['smsep']), clear_freq_range, int(metaData['usrp_fcenter']))
 
 
         self.logger.debug('end calc_clear_freq_on_raw_samples')


### PR DESCRIPTION
This pull request modifies `clear_frequency_server.c` in the CFS and `usrp_server.py` to support reading and writing independent USRP mixing frequencies for each radar at a dual site.  Previously the CFS could only track one center frequency at a time and would return an error such as

```
2025-07-25 17:13:01.432 ERROR clear_frequency_server.c:1485: ERROR: Clear Range is out of Usrp Range!
2025-07-25 17:13:01.432 ERROR clear_frequency_server.c:1486: ERROR: Please check your Clear Range and Usrp RF Rate settings.
```

Now, the `fcenter` shared memory object is updated by the `usrp_server` on each clear frequency request so that CFS can compare the requested clear search band to the correct center frequency for that radar.  I've tested this in the lab with one radar at 10.3-106. MHz and the other at 16.5-16.8 MHz (ie well outside the 5 MHz bandwidth of an individual USRP).  

@Hearing0 let me know if this seems reasonable - thanks!